### PR TITLE
Replaced concatenated strings with template literals in the test/utils.js

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -93,60 +93,60 @@ exports.encode_qp = {
         test.done();
     },
     "Don't break a line that's near but not over 76 chars" : function (test) {
-        const buffer = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
-                     "xxxxxxxxxxxxxxxxxx";
-        test.equals(utils.encode_qp(buffer+"123"), buffer+"123");
-        test.equals(utils.encode_qp(buffer+"1234"), buffer+"1234");
-        test.equals(utils.encode_qp(buffer+"12345"), buffer+"12345");
-        test.equals(utils.encode_qp(buffer+"123456"), buffer+"123456");
-        test.equals(utils.encode_qp(buffer+"1234567"), buffer+"12345=\n67");
-        test.equals(utils.encode_qp(buffer+"123456="), buffer+"12345=\n6=3D");
-        test.equals(utils.encode_qp(buffer+"123\n"), buffer+"123\n");
-        test.equals(utils.encode_qp(buffer+"1234\n"), buffer+"1234\n");
-        test.equals(utils.encode_qp(buffer+"12345\n"), buffer+"12345\n");
-        test.equals(utils.encode_qp(buffer+"123456\n"), buffer+"123456\n");
-        test.equals(utils.encode_qp(buffer+"1234567\n"), buffer+"12345=\n67\n");
+        const buffer = `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\
+xxxxxxxxxxxxxxxxxx`;
+        test.equals(utils.encode_qp(`${buffer}123`), `${buffer}123`);
+        test.equals(utils.encode_qp(`${buffer}1234`), `${buffer}1234`);
+        test.equals(utils.encode_qp(`${buffer}12345`), `${buffer}12345`);
+        test.equals(utils.encode_qp(`${buffer}123456`), `${buffer}123456`);
+        test.equals(utils.encode_qp(`${buffer}1234567`), `${buffer}12345=\n67`);
+        test.equals(utils.encode_qp(`${buffer}123456=`), `${buffer}12345=\n6=3D`);
+        test.equals(utils.encode_qp(`${buffer}123\n`), `${buffer}123\n`);
+        test.equals(utils.encode_qp(`${buffer}1234\n`), `${buffer}1234\n`);
+        test.equals(utils.encode_qp(`${buffer}12345\n`), `${buffer}12345\n`);
+        test.equals(utils.encode_qp(`${buffer}123456\n`), `${buffer}123456\n`);
+        test.equals(utils.encode_qp(`${buffer}1234567\n`), `${buffer}12345=\n67\n`);
         test.equals(
-            utils.encode_qp(buffer+"123456=\n"), buffer+"12345=\n6=3D\n"
+            utils.encode_qp(`${buffer}123456=\n`), `${buffer}12345=\n6=3D\n`
         );
         test.done();
     },
     'Not allowed to break =XX escapes using soft line break' : function (test) {
         test.expect(10);
-        const buffer = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
-                     "xxxxxxxxxxxxxxxxxx";
+        const buffer = `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\
+xxxxxxxxxxxxxxxxxx`;
         test.equals(
-            utils.encode_qp(buffer+"===xxxxx"), buffer+"=3D=\n=3D=3Dxxxxx"
+            utils.encode_qp(`${buffer}===xxxxx`), `${buffer}=3D=\n=3D=3Dxxxxx`
         );
         test.equals(
-            utils.encode_qp(buffer+"1===xxxx"), buffer+"1=3D=\n=3D=3Dxxxx"
+            utils.encode_qp(`${buffer}1===xxxx`), `${buffer}1=3D=\n=3D=3Dxxxx`
         );
         test.equals(
-            utils.encode_qp(buffer+"12===xxx"), buffer+"12=3D=\n=3D=3Dxxx"
+            utils.encode_qp(`${buffer}12===xxx`), `${buffer}12=3D=\n=3D=3Dxxx`
         );
         test.equals(
-            utils.encode_qp(buffer+"123===xx"), buffer+"123=\n=3D=3D=3Dxx"
+            utils.encode_qp(`${buffer}123===xx`), `${buffer}123=\n=3D=3D=3Dxx`
         );
         test.equals(
-            utils.encode_qp(buffer+"1234===x"), buffer+"1234=\n=3D=3D=3Dx"
+            utils.encode_qp(`${buffer}1234===x`), `${buffer}1234=\n=3D=3D=3Dx`
         );
-        test.equals(utils.encode_qp(buffer+"12=\n"), buffer+"12=3D\n");
-        test.equals(utils.encode_qp(buffer+"123=\n"), buffer+"123=\n=3D\n");
-        test.equals(utils.encode_qp(buffer+"1234=\n"), buffer+"1234=\n=3D\n");
-        test.equals(utils.encode_qp(buffer+"12345=\n"), buffer+"12345=\n=3D\n");
+        test.equals(utils.encode_qp(`${buffer}12=\n`), `${buffer}12=3D\n`);
+        test.equals(utils.encode_qp(`${buffer}123=\n`), `${buffer}123=\n=3D\n`);
+        test.equals(utils.encode_qp(`${buffer}1234=\n`), `${buffer}1234=\n=3D\n`);
+        test.equals(utils.encode_qp(`${buffer}12345=\n`), `${buffer}12345=\n=3D\n`);
         test.equals(
-            utils.encode_qp(buffer+"123456=\n"), buffer+"12345=\n6=3D\n"
+            utils.encode_qp(`${buffer}123456=\n`), `${buffer}12345=\n6=3D\n`
         );
         test.done();
     },
     'some extra special cases we have had problems with' : function (test) {
         test.expect(2);
-        const buffer = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
-                     "xxxxxxxxxxxxxxxxxx";
-        test.equals(utils.encode_qp(buffer+"12=x=x"), buffer+"12=3D=\nx=3Dx");
+        const buffer = `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\
+xxxxxxxxxxxxxxxxxx`;
+        test.equals(utils.encode_qp(`${buffer}12=x=x`), `${buffer}12=3D=\nx=3Dx`);
         test.equals(
-            utils.encode_qp(buffer+"12345"+buffer+"12345"+buffer+"123456\n"),
-            buffer+"12345=\n"+buffer+"12345=\n"+buffer+"123456\n"
+            utils.encode_qp(`${buffer}12345${buffer}12345${buffer}123456\n`),
+            `${buffer}12345=\n${buffer}12345=\n${buffer}123456\n`
         );
         test.done();
     },


### PR DESCRIPTION
updates: https://github.com/haraka/Haraka/issues/2129