### PR TITLE
change names of 1024 base units to mach IEC 80000-13:2008 standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,7 +236,9 @@ exports.indexOfLF = function (buf, maxlength) {
 exports.prettySize = function (size) {
     if (size === 0 || !size) return 0;
     const i = Math.floor(Math.log(size)/Math.log(1024));
-    const units = ['B', 'kB', 'MB', 'GB', 'TB'];
+    // https://wikipedia.org/wiki/Binary_prefix units with 1024 base
+    // should use binary prefix
+    const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
     return (size/Math.pow(1024,i)).toFixed(2) * 1 + '' + units[i];
 };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -365,24 +365,26 @@ exports.elapsed = {
 };
 
 exports.prettySize = {
-    'formats into 1024 sized kB': function (test) {
+    // https://wikipedia.org/wiki/Binary_prefix units with 1024 base
+    // should use binary prefix
+    'formats into 1024 sized KiB': function (test) {
         test.expect(1);
-        test.equal(utils.prettySize(10000), '9.77kB');
+        test.equal(utils.prettySize(10000), '9.77KiB');
         test.done();
     },
-    'formats into 1024 sized MB': function (test) {
+    'formats into 1024 sized MiB': function (test) {
         test.expect(1);
-        test.equal(utils.prettySize(10000000), '9.54MB');
+        test.equal(utils.prettySize(10000000), '9.54MiB');
         test.done();
     },
-    'formats into 1024 sized GB': function (test) {
+    'formats into 1024 sized GiB': function (test) {
         test.expect(1);
-        test.equal(utils.prettySize(10000000000), '9.31GB');
+        test.equal(utils.prettySize(10000000000), '9.31GiB');
         test.done();
     },
-    'formats into 1024 sized TB': function (test) {
+    'formats into 1024 sized TiB': function (test) {
         test.expect(1);
-        test.equal(utils.prettySize(10000000000000), '9.09TB');
+        test.equal(utils.prettySize(10000000000000), '9.09TiB');
         test.done();
     },
 }


### PR DESCRIPTION
units with 1024 base should use binary prefix
https://wikipedia.org/wiki/Binary_prefix